### PR TITLE
Remove the redundant changes. See details.

### DIFF
--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -217,6 +217,9 @@ interface Foldable (t : Type -> Type) where
   foldl : (func : acc -> elem -> acc) -> (init : acc) -> (input : t elem) -> acc
   foldl f z t = foldr (flip (.) . flip f) id t z
 
+  ||| Test whether the structure is empty.
+  null : t elem -> Bool
+
 ||| Similar to `foldl`, but uses a function wrapping its result in a `Monad`.
 ||| Consequently, the final value is wrapped in the same `Monad`.
 public export

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -274,7 +274,8 @@ public export
 Foldable (Either e) where
   foldr f acc (Left _) = acc
   foldr f acc (Right x) = f x acc
-  null _ = False
+  null (Left _) = True
+  null (Right _) = False
 
 public export
 Traversable (Either e) where

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -180,6 +180,8 @@ public export
 Foldable Maybe where
   foldr _ z Nothing  = z
   foldr f z (Just x) = f x z
+  null Nothing = True
+  null (Just _) = False
 
 public export
 Traversable Maybe where
@@ -272,6 +274,7 @@ public export
 Foldable (Either e) where
   foldr f acc (Left _) = acc
   foldr f acc (Right x) = f x acc
+  null _ = False
 
 public export
 Traversable (Either e) where
@@ -340,6 +343,9 @@ Foldable List where
 
   foldl f q [] = q
   foldl f q (x::xs) = foldl f (f q x) xs
+
+  null [] = True
+  null (_::_) = False
 
 public export
 Applicative List where


### PR DESCRIPTION
Although the implementation of `null` for `Either` can successfully be type checked and build, when using `null (Right _)` directly it must cause errors for not have given type information directly.
Although explicitly give its type by `the` works, it is a error at not dual type-check nor compile-time, but the runtime which I think can be dangerous. I haven't see such issues like this until yesterday (UTC +8), and have no idea to deal with it.
I feel sorry for the wasting CI and your patience.
I am still wondering what's the method to solve problems like this and how to avoid or solve it during my daily programming.
Sincerely apologize.